### PR TITLE
feat: add OpenTelemetry (OTEL) instrumentation support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,7 +14,7 @@ required_modifiable_fields:
   - custom_download_password
 
 app_name: cloudserver
-__app_version: 26.4.25643
+__app_version: 26.6.25935
 
 linux_installer_checksum: "f3b79580e6998560e1e31066d7fcdbc2cf5b8d4b35c97855b64aa35b6c108028"
 windows_installer_checksum: "76ac384658f926765f28b86db676dfa2eca4fbae0040cc17645c8b3b4eab86fd"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -50,8 +50,8 @@ otel_java_options:
   - "-Dotel.resource.attributes=deployment.environment={{ otel_environment }},service.namespace={{ otel_namespace }},customer={{ otel_customer }}"
   - "-Dotel.exporter.otlp.endpoint={{ otel_alloy_endpoint }}"
   - "-Dotel.exporter.otlp.protocol=grpc"
-  - "-Dotel.metrics.exporter=none"
-  - "-Dotel.logs.exporter=none"
+  - "-Dotel.metrics.exporter=otlp"
+  - "-Dotel.logs.exporter=otlp"
 
 # Keep user-provided extra JVM options separate from OTEL options
 extra_java_options: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,7 +14,7 @@ required_modifiable_fields:
   - custom_download_password
 
 app_name: cloudserver
-__app_version: 26.4.25496
+__app_version: 26.4.25643
 
 linux_installer_checksum: "f3b79580e6998560e1e31066d7fcdbc2cf5b8d4b35c97855b64aa35b6c108028"
 windows_installer_checksum: "76ac384658f926765f28b86db676dfa2eca4fbae0040cc17645c8b3b4eab86fd"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,7 +14,7 @@ required_modifiable_fields:
   - custom_download_password
 
 app_name: cloudserver
-__app_version: 26.4.25487
+__app_version: 26.4.25496
 
 linux_installer_checksum: "f3b79580e6998560e1e31066d7fcdbc2cf5b8d4b35c97855b64aa35b6c108028"
 windows_installer_checksum: "76ac384658f926765f28b86db676dfa2eca4fbae0040cc17645c8b3b4eab86fd"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,9 +26,41 @@ __server_port: 8080
 __java_version: 17.0.3_7
 
 
+# OpenTelemetry Configuration
+otel_enabled: false
+otel_version: "2.23.0"
+otel_download_url: "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v{{ otel_version }}/opentelemetry-javaagent.jar"
+otel_jar_name: "opentelemetry-javaagent.jar"
+# Where the jar will be stored (make sure to define otel_jar_directory in vars/os specific files or default here)
+otel_jar_full_path: "{{ installation_root_folder }}/otel/{{ otel_jar_name }}"
+
+otel_service_name: "{{ app_name }}"
+otel_environment: "prod"
+otel_namespace: "daict"
+otel_customer: "default"
+otel_alloy_endpoint: "http://{{ otel_alloy_host }}:{{ otel_alloy_port }}"
+otel_alloy_host: "localhost"
+otel_alloy_port: 4317
+
+
+# Define the OTEL options as a list
+otel_java_options:
+  - "-javaagent:{{ otel_jar_full_path }}"
+  - "-Dotel.service.name={{ otel_service_name }}"
+  - "-Dotel.resource.attributes=deployment.environment={{ otel_environment }},service.namespace={{ otel_namespace }},customer={{ otel_customer }}"
+  - "-Dotel.exporter.otlp.endpoint={{ otel_alloy_endpoint }}"
+  - "-Dotel.exporter.otlp.protocol=grpc"
+  - "-Dotel.metrics.exporter=none"
+  - "-Dotel.logs.exporter=none"
+
+# This logic adds otel options to extra_java_options ONLY if otel_enabled is true
+extra_java_options: "{{ otel_java_options if otel_enabled else [] }}"
+
+### Add OTel and extra java options seperately ###
+
 base_java_options: []
 
-extra_java_options: []
+# extra_java_options: []
 
 java_options: "{{ base_java_options + extra_java_options }}"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,7 +14,7 @@ required_modifiable_fields:
   - custom_download_password
 
 app_name: cloudserver
-__app_version: 26.6.25935
+__app_version: 25.8.24230
 
 linux_installer_checksum: "f3b79580e6998560e1e31066d7fcdbc2cf5b8d4b35c97855b64aa35b6c108028"
 windows_installer_checksum: "76ac384658f926765f28b86db676dfa2eca4fbae0040cc17645c8b3b4eab86fd"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -53,16 +53,16 @@ otel_java_options:
   - "-Dotel.metrics.exporter=none"
   - "-Dotel.logs.exporter=none"
 
-# This logic adds otel options to extra_java_options ONLY if otel_enabled is true
-extra_java_options: "{{ otel_java_options if otel_enabled else [] }}"
+# Keep user-provided extra JVM options separate from OTEL options
+extra_java_options: []
 
-### Add OTel and extra java options seperately ###
+# Add OTEL options only when enabled
+enabled_otel_java_options: "{{ otel_java_options if otel_enabled else [] }}"
 
 base_java_options: []
 
-# extra_java_options: []
-
-java_options: "{{ base_java_options + extra_java_options }}"
+# Final JVM options used by startup scripts/templates
+java_options: "{{ base_java_options + extra_java_options + enabled_otel_java_options }}"
 
 __db_connection_string: "jdbc:postgresql://localhost:5432/cloudserver"
 __db_username: postgres

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,7 +14,7 @@ required_modifiable_fields:
   - custom_download_password
 
 app_name: cloudserver
-__app_version: 25.8.24230
+__app_version: 26.4.25487
 
 linux_installer_checksum: "f3b79580e6998560e1e31066d7fcdbc2cf5b8d4b35c97855b64aa35b6c108028"
 windows_installer_checksum: "76ac384658f926765f28b86db676dfa2eca4fbae0040cc17645c8b3b4eab86fd"

--- a/tasks/linux-install.yml
+++ b/tasks/linux-install.yml
@@ -83,6 +83,22 @@
     owner: "{{ ansible_user_id }}"
   become: yes
 
+- name: Create directory for OTEL jar
+  file:
+    path: "{{ installation_root_folder }}/otel"
+    state: directory
+    owner: "{{ ansible_user_id }}"
+  become: yes
+  when: otel_enabled | bool
+
+- name: Download OpenTelemetry Java agent jar
+  get_url:
+    url: "{{ otel_download_url }}"
+    dest: "{{ otel_jar_full_path }}"
+    mode: '0644'
+    timeout: "{{ download_timeout | default(60) }}"
+  when: otel_enabled | bool
+
 - name: make sure unzip folder exist
   file:
     path: "{{ temp_folder }}/{{ (installer_file_name | splitext)[0] }}"


### PR DESCRIPTION
## Summary
- Add `otel_enabled: false` flag (opt-in, no impact on existing deployments)
- Add OTEL config variables: agent version, download URL, Alloy endpoint, resource attributes
- Add install tasks to create `otel/` directory and download `opentelemetry-javaagent.jar` when enabled
- Compose `java_options` from `base + extra + enabled_otel` — startup templates updated accordingly

## Enabling OTEL
Set in your playbook/inventory:
```yaml
otel_enabled: true
otel_alloy_host: <your-grafana-alloy-host>
otel_environment: prod
otel_customer: <customer-name>
```

## Test plan
- [ ] Verify role installs cleanly with `otel_enabled: false` (default) — no behavioral change
- [ ] Verify OTEL jar is downloaded and directory created when `otel_enabled: true`
- [ ] Verify Java process starts with OTEL agent flags when enabled
- [ ] Verify metrics/traces appear in Grafana Alloy

🤖 Generated with [Claude Code](https://claude.com/claude-code)