### PR TITLE
Upgrade Java version to 25.0.4_7

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,7 +23,7 @@ main_class: "com.experitest.cloudserver.CloudServerMain"
 
 __server_port: 8080
 
-__java_version: 17.0.18_8
+__java_version: 25.0.4_7
 
 
 # OpenTelemetry Configuration


### PR DESCRIPTION
Upgrades the Java version to **25.0.4_7** to standardize on a single version across all Ansible roles.

- Updated `__java_version` in `defaults/main.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)